### PR TITLE
fix: dependency bump deno v1.20.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM denoland/deno:alpine-1.19.0
+FROM denoland/deno:alpine-1.20.3
 
 EXPOSE 3002
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@
    <a href="https://github.com/pmprosociety/authcompanion/stargazers">
      <img alt="GitHub stars" src="https://img.shields.io/github/stars/pmprosociety/authcompanion">
    </a>
-   <a href="https://deno.land">
-     <img src="https://img.shields.io/badge/deno-1.19.0-green?logo=deno"/>
+   <a href="https://github.com/denoland/deno/releases/tag/v1.20.3">
+     <img src="https://img.shields.io/badge/deno-v1.20.3-green?logo=deno"/>
    </a>
 
 </div>

--- a/client/home_page.html
+++ b/client/home_page.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="shortcut icon" href="https://unpkg.com/favicon.ico" />
-  <script src="https://unpkg.com/vue@3.2.25/dist/vue.global.prod.js"></script>
+  <script src="https://unpkg.com/vue@3.2.31/dist/vue.global.prod.js"></script>
   <link rel="stylesheet" href="https://unpkg.com/@tailwindcss/forms@0.4.0/dist/forms.min.css" />
   <script type="module" src="https://cdn.skypack.dev/twind/shim"></script>
   <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />

--- a/client/login_page.html
+++ b/client/login_page.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="shortcut icon" href="https://unpkg.com/favicon.ico" />
-  <script src="https://unpkg.com/vue@3.2.25/dist/vue.global.prod.js"></script>
+  <script src="https://unpkg.com/vue@3.2.31/dist/vue.global.prod.js"></script>
   <link rel="stylesheet" href="https://unpkg.com/@tailwindcss/forms@0.4.0/dist/forms.min.css" />
   <script type="module" src="https://cdn.skypack.dev/twind/shim"></script>
   <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />

--- a/client/profile_page.html
+++ b/client/profile_page.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="shortcut icon" href="https://unpkg.com/favicon.ico" />
-  <script src="https://unpkg.com/vue@3.2.25/dist/vue.global.prod.js"></script>
+  <script src="https://unpkg.com/vue@3.2.31/dist/vue.global.prod.js"></script>
   <link rel="stylesheet" href="https://unpkg.com/@tailwindcss/forms@0.4.0/dist/forms.min.css" />
   <script type="module" src="https://cdn.skypack.dev/twind/shim"></script>
   <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />

--- a/client/recovery_page.html
+++ b/client/recovery_page.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="shortcut icon" href="https://unpkg.com/favicon.ico" />
-  <script src="https://unpkg.com/vue@3.2.25/dist/vue.global.prod.js"></script>
+  <script src="https://unpkg.com/vue@3.2.31/dist/vue.global.prod.js"></script>
   <link rel="stylesheet" href="https://unpkg.com/@tailwindcss/forms@0.4.0/dist/forms.min.css" />
   <script type="module" src="https://cdn.skypack.dev/twind/shim"></script>
   <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />

--- a/client/registration_page.html
+++ b/client/registration_page.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="shortcut icon" href="https://unpkg.com/favicon.ico" />
-  <script src="https://unpkg.com/vue@3.2.25/dist/vue.global.prod.js"></script>
+  <script src="https://unpkg.com/vue@3.2.31/dist/vue.global.prod.js"></script>
   <link rel="stylesheet" href="https://unpkg.com/@tailwindcss/forms@0.4.0/dist/forms.min.css" />
   <script type="module" src="https://cdn.skypack.dev/twind/shim"></script>
   <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />

--- a/deps.ts
+++ b/deps.ts
@@ -6,7 +6,7 @@ export {
   Response,
   Router,
   Status,
-} from "https://deno.land/x/oak@v10.4.0/mod.ts";
+} from "https://deno.land/x/oak@v10.5.1/mod.ts";
 export { DB, SqliteError } from "https://deno.land/x/sqlite@v3.2.1/mod.ts";
 export { compare, hash } from "https://deno.land/x/bcrypt@v0.3.0/mod.ts";
 export {
@@ -17,9 +17,9 @@ export {
 } from "https://deno.land/x/djwt@v2.4/mod.ts";
 export type { Header, Payload } from "https://deno.land/x/djwt@v2.4/mod.ts";
 //remove me at some point
-export { v4 } from "https://deno.land/std@0.126.0/uuid/mod.ts";
-export * as log from "https://deno.land/std@0.126.0/log/mod.ts";
-export { LogRecord } from "https://deno.land/std@0.126.0/log/logger.ts";
+export { v4 } from "https://deno.land/std@0.132.0/uuid/mod.ts";
+export * as log from "https://deno.land/std@0.132.0/log/mod.ts";
+export { LogRecord } from "https://deno.land/std@0.132.0/log/logger.ts";
 export { SmtpClient } from "https://deno.land/x/smtp@v0.7.0/mod.ts";
 export type { ConnectConfigWithAuthentication } from "https://deno.land/x/smtp@v0.7.0/mod.ts";
 export {
@@ -27,8 +27,8 @@ export {
   green,
   red,
   yellow,
-} from "https://deno.land/std@0.126.0/fmt/colors.ts";
-export { format } from "https://deno.land/std@0.126.0/datetime/mod.ts";
+} from "https://deno.land/std@0.132.0/fmt/colors.ts";
+export { format } from "https://deno.land/std@0.132.0/datetime/mod.ts";
 import * as superstruct from "https://cdn.skypack.dev/superstruct";
 export { superstruct };
-export * as base64 from "https://deno.land/std@0.126.0/encoding/base64.ts";
+export * as base64 from "https://deno.land/std@0.132.0/encoding/base64.ts";

--- a/tests/serverIntegration.test.ts
+++ b/tests/serverIntegration.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.126.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.132.0/testing/asserts.ts";
 import { db } from "../db/db.ts";
 
 function purgeTestData() {


### PR DESCRIPTION
Takes vue, oak, deno and std to the latest versions. 

Make sure to run `deno upgrade` to get this latest version. 